### PR TITLE
1st Tests! Shallow Rendering w/ Enzyme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ My goal with this project, is for it to serve as a practical example that goes b
 
 ## The App
 
+```
+# Install dependencies
+npm install
+
+# Start development servers (client + API)
+npm start
+
+# Run tests
+npm test
+```
+
 ![reactmaillistanimation](https://cloud.githubusercontent.com/assets/1240178/14709257/f80d4ec6-078c-11e6-95bc-63c5c2817da8.gif)
 
 Some Basic Features/Highlights. _Hint: these should become tests :)_
@@ -85,7 +96,21 @@ Using [axios](https://github.com/mzabriskie/axios), a [Promise](https://develope
 
 ### Testing
 
-TODO
+- Test runner: [mocha](http://mochajs.org/)
+- Assertions (and spies): [expect](https://www.npmjs.com/package/expect)
+- Unit testing React components with shallow rendering [Enzyme](http://airbnb.io/enzyme/docs/api/shallow.html)
+
+Unit tests live directly adjacent to the file under test. Example:
+
+```
+src/some/path/someModule.js
+src/some/path/someModule.test.js
+```
+
+Running Tests
+- Run all tests: `npm test`
+- Run specific tests: `npm test -- --grep='some pattern here'`
+- Run tests with a watch: `npm test -- --watch`
 
 ### Some Visual Highlights
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "nwb clean",
     "start": "npm run nwb-server & npm run json-server",
     "nwb-server": "nwb serve --fallback --auto-install --reload",
-    "test": "nwb test",
+    "test": "mocha ./src/**/*.test.js",
     "test:watch": "nwb test --server",
     "json-server": "json-server json-server.js --port=3001 --delay=500"
   },
@@ -22,10 +22,14 @@
     "react-router": "~2.2.2"
   },
   "devDependencies": {
+    "enzyme": "~2.2.0",
+    "expect": "~1.18.0",
     "faker": "^3.1.0",
     "json-server": "^0.8.9",
+    "mocha": "~2.4.5",
     "nwb": "~0.9.2",
-    "nwb-sass": "~0.5.0"
+    "nwb-sass": "~0.5.0",
+    "react-addons-test-utils": "~15.0.1"
   },
   "author": "",
   "license": "MIT",

--- a/src/components/MessageDetail/MessageDetail.test.js
+++ b/src/components/MessageDetail/MessageDetail.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import expect from 'expect';
+
+import { MessageDetail } from './MessageDetail';
+
+describe('Component: MessageDetail', () => {
+  // Minimum required props to render w/o errors/warnings
+  const minProps = {
+    message: {},
+    deleteMessage: () => {},
+    toggleFlagged: () => {},
+  };
+
+  it('renders without exploding', () => {
+    expect(
+      shallow(<MessageDetail {...minProps} />).length
+    ).toEqual(1);
+  });
+
+  it('links back to the message listing "search" page', () => {
+    expect(
+      shallow(<MessageDetail {...minProps} />)
+        .find('Link').props().to
+    ).toEqual('/');
+  });
+
+  // Given props, render and pluck out the "Flag" button
+  const renderToFlagButton =
+    (props) => shallow(<MessageDetail {...props} />)
+      .find('button')
+      .find({onClick: props.toggleFlagged});
+
+  it('indicates whether the message is "flagged"', () => {
+    /** Given a message, assert that there is an "indicator"*/
+    const hasIndicator = (message) =>
+      renderToFlagButton({...minProps, message})
+        .hasClass('text-red');
+
+    expect(hasIndicator({flagged: true})).toEqual(true);
+    expect(hasIndicator({flagged: false})).toEqual(false);
+  });
+
+  it('toggles "flagged" status when flag button is clicked', () => {
+    const props = {
+      ...minProps,
+      toggleFlagged: expect.createSpy(),
+    };
+    renderToFlagButton(props)
+      .simulate('click');
+    expect(props.toggleFlagged).toHaveBeenCalled();
+  });
+
+  it('deletes itself when the "delete" button is clicked', () => {
+    const props = {
+      ...minProps,
+      deleteMessage: expect.createSpy(),
+    };
+    shallow(<MessageDetail {...props} />)
+      .find('button')
+      .find({onClick: props.deleteMessage})
+      .simulate('click');
+    expect(props.deleteMessage).toHaveBeenCalled();
+  });
+
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--compilers js:babel-core/register
+--recursive


### PR DESCRIPTION
This is the first step toward #4 
### Setup minimal test tooling - expect, enzyme, ES6

Update `npm test` to `mocha ./src/**/*.test.js`.
- Run tests once: `npm test`
- Run specific tests: `npm test -- --grep='some pattern here'`
- Run tests watch: `npm test -- --watch`

This pattern allows for tests to live directly adjacent to the file under test.
Example:

```
src/some/path/someModule.js
src/some/path/someModule.test.js
```

:warning: babel-core/register is currently available "by coincidence" due to nwb. This
will need to be addressed to stand alone from nwb when nwb is replaced (#2)
### 1st React component test! MessageDetail (enzyme)
#### Component: MessageDetail (Tests for `MessageDetail.js`)
- [x] renders without exploding
- [x] links back to the message listing "search" page
- [x] indicates whether the message is "flagged"
- [x] toggles "flagged" status when flag button is clicked
- [x] deletes itself when the "delete" button is clicked
